### PR TITLE
Feature/add example project

### DIFF
--- a/FluentBuilder.sln
+++ b/FluentBuilder.sln
@@ -13,7 +13,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentBuilder.UnitTests", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{4CDB95B4-DC73-460B-AD36-A461281D468F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentBuilder.Examples.UsingXunit", "example\FluentBuilder.Examples.UsingXunit\FluentBuilder.Examples.UsingXunit.csproj", "{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentBuilder.Examples.UsingXunit", "example\FluentBuilder.Examples.UsingXunit\FluentBuilder.Examples.UsingXunit.csproj", "{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentBuilder.Examples.Common", "example\FluentBuilder.Examples.Common\FluentBuilder.Examples.Common.csproj", "{11DE9CDA-4D22-4CF9-9ADE-A663B970587B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11DE9CDA-4D22-4CF9-9ADE-A663B970587B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11DE9CDA-4D22-4CF9-9ADE-A663B970587B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11DE9CDA-4D22-4CF9-9ADE-A663B970587B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11DE9CDA-4D22-4CF9-9ADE-A663B970587B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -41,6 +47,7 @@ Global
 		{73BE9D1A-A036-491A-98F8-663614AA935D} = {DFDAEB1C-E140-4174-A43A-3770A6361062}
 		{FF73CBD9-420B-463F-9FE9-FEE0101467B9} = {D9E429BF-D435-499D-8536-E9963B209ACE}
 		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4} = {4CDB95B4-DC73-460B-AD36-A461281D468F}
+		{11DE9CDA-4D22-4CF9-9ADE-A663B970587B} = {4CDB95B4-DC73-460B-AD36-A461281D468F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {235978DB-9EEA-4E21-8692-AC335C23DE86}

--- a/FluentBuilder.sln
+++ b/FluentBuilder.sln
@@ -7,9 +7,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DFDAEB1C-E14
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{D9E429BF-D435-499D-8536-E9963B209ACE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentBuilder", "src\FluentBuilder\FluentBuilder.csproj", "{73BE9D1A-A036-491A-98F8-663614AA935D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentBuilder", "src\FluentBuilder\FluentBuilder.csproj", "{73BE9D1A-A036-491A-98F8-663614AA935D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentBuilder.UnitTests", "test\FluentBuilder.UnitTests\FluentBuilder.UnitTests.csproj", "{FF73CBD9-420B-463F-9FE9-FEE0101467B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentBuilder.UnitTests", "test\FluentBuilder.UnitTests\FluentBuilder.UnitTests.csproj", "{FF73CBD9-420B-463F-9FE9-FEE0101467B9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{4CDB95B4-DC73-460B-AD36-A461281D468F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentBuilder.Examples.UsingXunit", "example\FluentBuilder.Examples.UsingXunit\FluentBuilder.Examples.UsingXunit.csproj", "{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,6 +29,10 @@ Global
 		{FF73CBD9-420B-463F-9FE9-FEE0101467B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF73CBD9-420B-463F-9FE9-FEE0101467B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF73CBD9-420B-463F-9FE9-FEE0101467B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -32,6 +40,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{73BE9D1A-A036-491A-98F8-663614AA935D} = {DFDAEB1C-E140-4174-A43A-3770A6361062}
 		{FF73CBD9-420B-463F-9FE9-FEE0101467B9} = {D9E429BF-D435-499D-8536-E9963B209ACE}
+		{5A37B8E0-1D7F-44E1-910A-8874B8B194F4} = {4CDB95B4-DC73-460B-AD36-A461281D468F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {235978DB-9EEA-4E21-8692-AC335C23DE86}

--- a/example/FluentBuilder.Examples.Common/FluentBuilder.Examples.Common.csproj
+++ b/example/FluentBuilder.Examples.Common/FluentBuilder.Examples.Common.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/example/FluentBuilder.Examples.UsingXunit/FluentBuilder.Examples.UsingXunit.csproj
+++ b/example/FluentBuilder.Examples.UsingXunit/FluentBuilder.Examples.UsingXunit.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/example/FluentBuilder.Examples.UsingXunit/FluentBuilder.Examples.UsingXunit.csproj
+++ b/example/FluentBuilder.Examples.UsingXunit/FluentBuilder.Examples.UsingXunit.csproj
@@ -20,4 +20,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FluentBuilder\FluentBuilder.csproj" />
+    <ProjectReference Include="..\FluentBuilder.Examples.Common\FluentBuilder.Examples.Common.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Add common example project, intended to hold common interfaces and contracts for the example projects to use.

This will provide for a consistent scenario with examples focusing on the technique used.