### PR TITLE
Add example sut classes

### DIFF
--- a/example/FluentBuilder.Examples.Common/Contracts/IContract.cs
+++ b/example/FluentBuilder.Examples.Common/Contracts/IContract.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentBuilder.Examples.Common.Contracts
+{
+    /// <summary>
+    /// Simulates a contract to expose a similar footprint for each SUT example
+    /// </summary>
+    internal interface IContract
+    {
+        public void Run();
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Dependencies/IDoSomething.cs
+++ b/example/FluentBuilder.Examples.Common/Dependencies/IDoSomething.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentBuilder.Examples.Common.Dependencies
+{
+    /// <summary>
+    /// Simulates a simple dependency
+    /// </summary>
+    internal interface IDoSomething
+    {
+        public void DoSomething();
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Dependencies/IDoSomethingElse.cs
+++ b/example/FluentBuilder.Examples.Common/Dependencies/IDoSomethingElse.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentBuilder.Examples.Common.Dependencies
+{
+    /// <summary>
+    /// Simulates a simple dependency
+    /// </summary>
+    internal interface IDoSomethingElse
+    {
+        public void DoSomethingElse();
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Dependencies/IGetSomeUsefulString.cs
+++ b/example/FluentBuilder.Examples.Common/Dependencies/IGetSomeUsefulString.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentBuilder.Examples.Common.Dependencies
+{
+    /// <summary>
+    /// Simulates a simple dependency
+    /// </summary>
+    internal interface IGetSomeUsefulString
+    {
+        public string GetSomeUsefulString();
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Dependencies/IUseSomeUsefulString.cs
+++ b/example/FluentBuilder.Examples.Common/Dependencies/IUseSomeUsefulString.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentBuilder.Examples.Common.Dependencies
+{
+    /// <summary>
+    /// Simulates a simple dependency
+    /// </summary>
+    internal interface IUseSomeUsefulString
+    {
+        public void UseSomeUsefulString(string usefulString);
+    }
+}

--- a/example/FluentBuilder.Examples.Common/FluentBuilder.Examples.Common.csproj
+++ b/example/FluentBuilder.Examples.Common/FluentBuilder.Examples.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/example/FluentBuilder.Examples.Common/Sut/ClassWithMultipleDependencies.cs
+++ b/example/FluentBuilder.Examples.Common/Sut/ClassWithMultipleDependencies.cs
@@ -1,0 +1,36 @@
+﻿using FluentBuilder.Examples.Common.Contracts;
+using FluentBuilder.Examples.Common.Dependencies;
+
+namespace FluentBuilder.Examples.Common.Sut
+{
+    /// <summary>
+    /// Simulates a SUT with multiple dependencies
+    /// </summary>
+    internal class ClassWithMultipleDependencies : IContract
+    {
+        private readonly IDoSomething _doSomething;
+        private readonly IDoSomethingElse _doSomethingElse;
+        private readonly IGetSomeUsefulString _getSomeUsefulString;
+        private readonly IUseSomeUsefulString _useSomeUsefulString;
+
+        public ClassWithMultipleDependencies(
+            IDoSomething doSomething,
+            IDoSomethingElse doSomethingElse,
+            IGetSomeUsefulString getSomeUsefulString,
+            IUseSomeUsefulString useSomeUsefulString)
+        {
+            _doSomething = doSomething;
+            _doSomethingElse = doSomethingElse;
+            _getSomeUsefulString = getSomeUsefulString;
+            _useSomeUsefulString = useSomeUsefulString;
+        }
+
+        public void Run()
+        {
+            _doSomething.DoSomething();
+            _doSomethingElse.DoSomethingElse();
+            var usefulString = _getSomeUsefulString.GetSomeUsefulString();
+            _useSomeUsefulString.UseSomeUsefulString(usefulString);
+        }
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Sut/ClassWithSingleDependency.cs
+++ b/example/FluentBuilder.Examples.Common/Sut/ClassWithSingleDependency.cs
@@ -1,0 +1,23 @@
+﻿using FluentBuilder.Examples.Common.Contracts;
+using FluentBuilder.Examples.Common.Dependencies;
+
+namespace FluentBuilder.Examples.Common.Sut
+{
+    /// <summary>
+    /// Simulates a SUT with a single dependency
+    /// </summary>
+    internal class ClassWithSingleDependency : IContract
+    {
+        private readonly IDoSomething _doSomething;
+
+        public ClassWithSingleDependency(IDoSomething doSomething)
+        {
+            _doSomething = doSomething;
+        }
+
+        public void Run()
+        {
+            _doSomething.DoSomething();
+        }
+    }
+}

--- a/example/FluentBuilder.Examples.Common/Sut/ClassWithoutDependencies.cs
+++ b/example/FluentBuilder.Examples.Common/Sut/ClassWithoutDependencies.cs
@@ -1,0 +1,14 @@
+﻿using FluentBuilder.Examples.Common.Contracts;
+
+namespace FluentBuilder.Examples.Common.Sut
+{
+    /// <summary>
+    /// Simulates a SUT without any dependencies
+    /// </summary>
+    internal class ClassWithoutDependencies : IContract
+    {
+        public void Run()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add three types of example classes and interfaces to `common`:
* `Contracts` Defines behavior of SUT classes for a unified experience in the example projects.
* `Dependencies` Defines dependencies of the SUT classes.
* `Sut` Defines a set of SUT classes to be used in the exampe projects.